### PR TITLE
Fix selection of images from script directory

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,5 @@
+colorWeight: 0.6
+contentWeight: 0.4
+cachePath: features.db
+histogramBins: 16
+contentSize: 8

--- a/image_cluster_selector.py
+++ b/image_cluster_selector.py
@@ -1,0 +1,141 @@
+import argparse
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import yaml
+from PIL import Image
+import numpy as np
+
+
+def load_config(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def init_db(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS features (path TEXT PRIMARY KEY, hist BLOB, content BLOB)"
+    )
+    conn.commit()
+    return conn
+
+
+def has_features(conn, path):
+    cur = conn.execute("SELECT 1 FROM features WHERE path=?", (path,))
+    return cur.fetchone() is not None
+
+
+def save_features(conn, path, hist, content):
+    conn.execute(
+        "INSERT OR REPLACE INTO features(path, hist, content) VALUES(?,?,?)",
+        (
+            path,
+            hist.astype(np.float64).tobytes(),
+            content.astype(np.float32).tobytes(),
+        ),
+    )
+    conn.commit()
+
+
+def load_all_features(conn):
+    result = []
+    for path, hist_blob, cont_blob in conn.execute(
+        "SELECT path, hist, content FROM features"
+    ):
+        hist = np.frombuffer(hist_blob, dtype=np.float64)
+        content = np.frombuffer(cont_blob, dtype=np.float32)
+        result.append({"path": path, "hist": hist, "content": content})
+    return result
+
+
+def compute_color_histogram(img, bins):
+    arr = np.array(img)
+    hist_r, _ = np.histogram(arr[:, :, 0], bins=bins, range=(0, 256), density=True)
+    hist_g, _ = np.histogram(arr[:, :, 1], bins=bins, range=(0, 256), density=True)
+    hist_b, _ = np.histogram(arr[:, :, 2], bins=bins, range=(0, 256), density=True)
+    return np.concatenate([hist_r, hist_g, hist_b])
+
+
+def compute_content_vector(img, size):
+    gray = img.convert("L").resize((size, size))
+    arr = np.array(gray, dtype=np.float32) / 255.0
+    return arr.flatten()
+
+
+def extract_features(path, config):
+    with Image.open(path) as img:
+        img = img.convert("RGB")
+        hist = compute_color_histogram(img, config.get("histogramBins", 16))
+        content = compute_content_vector(img, config.get("contentSize", 8))
+    return hist, content
+
+
+def preprocess_images(files, db_path, config):
+    """Extract and cache features for image files."""
+
+    def process(image_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            if not has_features(conn, image_path):
+                hist, content = extract_features(image_path, config)
+                save_features(conn, image_path, hist, content)
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor() as executor:
+        list(executor.map(process, files))
+
+
+def select_images(features, config, count=5):
+    import random
+
+    if not features:
+        return []
+    seed = random.choice(features)
+    color_w = config.get("colorWeight", 0.6)
+    content_w = config.get("contentWeight", 0.4)
+    scores = []
+    for item in features:
+        color_dist = np.linalg.norm(seed["hist"] - item["hist"])
+        content_dist = np.linalg.norm(seed["content"] - item["content"])
+        score = color_w * color_dist + content_w * content_dist
+        scores.append({"path": item["path"], "score": float(score)})
+    scores = sorted(scores, key=lambda x: x["score"])
+    scores = [s for s in scores if s["path"] != seed["path"]]
+    return scores[:count]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Image clustering and selection")
+    parser.add_argument("config", help="YAML configuration file")
+    parser.add_argument(
+        "--images",
+        default=str(Path(__file__).parent),
+        help="Folder containing images (default: script directory)",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=5,
+        help="Number of images to return",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    db_path = config.get("cachePath", "features.db")
+    conn = init_db(db_path)
+
+    exts = {".jpg", ".jpeg", ".png", ".bmp", ".gif"}
+    files = [str(p) for p in Path(args.images).rglob("*") if p.suffix.lower() in exts]
+
+    preprocess_images(files, db_path, config)
+    features = load_all_features(conn)
+    result = select_images(features, config, args.count)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.txt
+++ b/readme.txt
@@ -1,23 +1,31 @@
-Phát triển hệ thống Image Clustering & Selection với các tính năng:
+# Image Clustering & Selection
 
-CORE FEATURES:
-- Phân tích màu sắc: RGB histogram, dominant colors extraction
-- Phân tích nội dung: object detection (YOLO/ResNet), scene classification
-- Thuật toán matching: weighted scoring (60% color, 40% content)
-- Caching: lưu pre-computed features để tăng tốc
+Ứng dụng này được viết bằng **Python 3** nhằm trích xuất và so khớp đặc trưng ảnh.
+Chương trình hỗ trợ phân tích màu sắc, vector nội dung đơn giản và lưu cache đặc
+trưng vào SQLite để tăng tốc xử lý. Việc trích xuất đặc trưng được thực hiện song
+song, mỗi luồng sử dụng kết nối SQLite riêng nên có thể chạy ổn định trên Windows.
 
-TECHNICAL SPECS:
-- Framework: Python 3.9+, FastAPI cho API
-- Libraries: OpenCV, scikit-image, torch/tensorflow
-- Database: SQLite cho tracking history
-- Config: YAML file cho tuning parameters
+## Sử dụng
 
-WORKFLOW:
-1. Pre-process: Extract & cache features của toàn bộ ảnh
-2. Runtime: Random seed → Calculate distances → Select top-4 → Validate uniqueness
-3. Output: JSON với paths + similarity scores + preview grid
+```
+python image_cluster_selector.py config.yml --images /path/to/images --count 5
+```
 
-CONSTRAINTS:
-- Max processing time: 2s cho 1000 ảnh
-- Memory efficient: batch processing cho large datasets
-- Dùng python hoặc c# (console app trên windows)
+Nếu không chỉ định `--images`, chương trình sẽ tìm ảnh trong cùng thư mục với tập tin Python.
+
+Đầu ra là JSON liệt kê các ảnh được chọn cùng điểm số tương đồng.
+
+### Cấu hình mẫu
+
+```yaml
+colorWeight: 0.6
+contentWeight: 0.4
+cachePath: features.db
+histogramBins: 16
+contentSize: 8
+```
+
+## Ghi chú
+
+Mã nguồn mới chỉ là khung cơ bản, chưa tích hợp các mô hình deep learning. Người dùng có thể bổ sung thư viện YOLO/ResNet tuỳ ý.
+Chương trình yêu cầu cài đặt các gói `Pillow`, `PyYAML` và `numpy` trước khi chạy.


### PR DESCRIPTION
## Summary
- open a SQLite connection per worker thread when caching features
- wait for preprocessing threads to finish
- clarify that each thread uses its own connection in the README
- note Python dependencies in the README

## Testing
- `python image_cluster_selector.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6864105f05ec832eaa1a8cf0a0b0e593